### PR TITLE
fix: add tributes default field to stripe metadata

### DIFF
--- a/add-on-snippets/stripe/add-tributes-meta.php
+++ b/add-on-snippets/stripe/add-tributes-meta.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This function will add tributes meta to stripe metadata.
+ *
+ * @param array $charge_args Charge Arguments.
+ *
+ * @return mixed
+ */
+function give_stripe_custom_payment_meta( $charge_args ) {
+
+	$donation_id = $charge_args['metadata']['Donation Post ID'];
+
+	$tribute_text       = Give()->payment_meta->get_meta( $donation_id, '_give_tributes_type', true );
+	$tribute_first_name = Give()->payment_meta->get_meta( $donation_id, '_give_tributes_first_name', true );
+	$tribute_last_name  = Give()->payment_meta->get_meta( $donation_id, '_give_tributes_last_name', true );
+
+	$custom_meta_fields = array(
+		$tribute_text => "{$tribute_first_name} {$tribute_last_name}",
+	);
+
+	$charge_args['metadata'] = array_merge( $charge_args['metadata'], $custom_meta_fields );
+
+	return $charge_args;
+}
+
+add_filter( 'give_stripe_create_charge_args', 'give_stripe_custom_payment_meta', 10, 2 );


### PR DESCRIPTION
## Description
This PR is created to add default tributes field to Stripe metadata.

## How was this PR tested?
I've tested this PR by processing a donation with Stripe + Tributes.

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/1852711/48008715-3483a780-e140-11e8-8beb-3cb3c2ed3db6.png)

## Types of changes
Bug fix (a non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
