### PR TITLE
fix: update snippet for passing custom metadata to Stripe payments #98

### DIFF
--- a/gateway-customizations/stripe-pass-custom-meta-for-payments.php
+++ b/gateway-customizations/stripe-pass-custom-meta-for-payments.php
@@ -6,18 +6,23 @@
  * the array that is passed to Stripe when a payment is made. Custom field data
  * can be found under Metadata in the Stripe payment details screen.
  *
- * @param $charge_args   array Arguments passed to Stripe payment gateway.
- * @param $donation_data array Data associated with the current donation.
+ * @param array $charge_args Arguments passed to Stripe payment gateway.
  *
  * @return array
  */
-function give_stripe_custom_payment_meta( $charge_args, $donation_data ) {
+function give_stripe_custom_payment_meta( $charge_args ) {
+
+	// Sanitize the input posted data to the form.
+	$posted_data = give_clean( filter_input_array( INPUT_POST ) );
+
+	// Prepare metadata fields list.
 	$custom_meta_fields = array(
-		'Text Field' => ! empty( $_POST['text_field'] ) ? $_POST['text_field'] : 'undefined',
-		'Dropdown Field' => ! empty( $_POST['dropdown_field'] ) ? $_POST['dropdown_field'][0] : 'undefined',
+		'Text Field'     => ! empty( $posted_data['text_field'] ) ? $posted_data['text_field'] : 'undefined',
+		'Dropdown Field' => ! empty( $posted_data['dropdown_field'] ) ? $posted_data['dropdown_field'][0] : 'undefined',
+		'Donor Comment'  => ! empty( $posted_data['give_comment'] ) ? $posted_data['give_comment'] : '',
 	);
 	$charge_args['metadata'] = array_merge( $charge_args['metadata'], $custom_meta_fields );
 
 	return $charge_args;
 }
-add_filter( 'give_stripe_create_charge_args', 'give_stripe_custom_payment_meta', 10, 2 );
+add_filter( 'give_stripe_create_charge_args', 'give_stripe_custom_payment_meta', 10 );


### PR DESCRIPTION
## Description
This PR resolves #98 

@samsmith89 Can you test this updated snippet for Stripe metadata?

## Visuals
![image](https://user-images.githubusercontent.com/1852711/54406124-eb032480-46fe-11e9-8b34-24b7b8702760.png)

## How Has This Been Tested?
I've tested this PR by processing a donation with Stripe to ensure that the metadata fields can be passed using the snippet.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.